### PR TITLE
Fix future-compat warning

### DIFF
--- a/src/thumb.rs
+++ b/src/thumb.rs
@@ -14,14 +14,14 @@ pub fn analyze(
             panic!(
                 "BUG: unknown instruction {:02x}{:02x}",
                 $first[1], $first[0]
-            );
+            )
         };
 
         ($first:expr, $second:expr) => {
             panic!(
                 "BUG: unknown instruction {:02x}{:02x} {:02x}{:02x}",
                 $first[1], $first[0], $second[1], $second[0]
-            );
+            )
         };
     }
 


### PR DESCRIPTION
The macro was used in expression position, so the trailing `;` should be removed as it isn't valid there.