### PR TITLE
Teach the parser about more attributes

### DIFF
--- a/src/ir.rs
+++ b/src/ir.rs
@@ -126,9 +126,15 @@ fn attribute(i: &str) -> IResult<&str, Attribute> {
     let (i, attr) = take_while1(|c: char| c.is_alphabetic() || c == '_')(i)?;
 
     let i = match attr {
-        "dereferenceable" | "dereferenceable_or_null" => {
+        "dereferenceable" | "dereferenceable_or_null" | "alignstack" => {
             let i = char('(')(i)?.0;
             let i = digit1(i)?.0;
+            char(')')(i)?.0
+        }
+
+        "sret" | "preallocated" | "inalloca" | "elementtype" | "byval" | "byref" => {
+            let i = char('(')(i)?.0;
+            let i = type_(i)?.0;
             char(')')(i)?.0
         }
 

--- a/src/ir/define.rs
+++ b/src/ir/define.rs
@@ -678,5 +678,22 @@ mod tests {
                 }
             ))
         );
+
+        assert_eq!(
+            super::parse(include_str!("define/parse6.ll").trim()),
+            Ok((
+                "",
+                Define {
+                    name: "_defmt_acquire",
+                    stmts: vec![Stmt::Other],
+                    sig: FnSig {
+                        inputs: vec![Type::Pointer(Box::new(Type::Alias(
+                            "core::option::Option<defmt::InternalFormatter>"
+                        )))],
+                        output: None,
+                    },
+                }
+            ))
+        );
     }
 }

--- a/src/ir/define/parse6.ll
+++ b/src/ir/define/parse6.ll
@@ -1,0 +1,3 @@
+define dso_local void @_defmt_acquire(%"core::option::Option<defmt::InternalFormatter>"* noalias nocapture sret(%"core::option::Option<defmt::InternalFormatter>") dereferenceable(12) %0) unnamed_addr #0 !dbg !5972 {
+  ret void, !dbg !7208
+}


### PR DESCRIPTION
rustc will occasionally emit an `sret(<ty>)` attribute. This teaches cargo-call-stack how to parse that (and a few other attributes).