### PR TITLE
Decode `str` with post-indexed operand

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1013,7 +1013,7 @@ fn run() -> Result<i32, failure::Error> {
                                 *llvm_stack, stack,
                                 "BUG: LLVM reported that `{}` uses {} bytes of stack but \
                                  this doesn't match our analysis",
-                                canonical_name, stack
+                                canonical_name, llvm_stack
                             );
                         }
                     }


### PR DESCRIPTION
`str     r11, [sp, #-4]!` will store `sp - 4` in `sp`; this PR accounts for that (but many other instructions can also use this addressing mode, so the decoder is still fairly incomplete)