### PR TITLE
Ignore LLVM's stack usage info when there's inline asm

### DIFF
--- a/cortex-m-examples/examples/div64.rs
+++ b/cortex-m-examples/examples/div64.rs
@@ -1,0 +1,25 @@
+#![no_main]
+#![no_std]
+
+use core::sync::atomic::{AtomicUsize, Ordering};
+
+use cortex_m_rt::{entry, exception};
+use panic_halt as _;
+
+static X: AtomicUsize = AtomicUsize::new(0);
+
+#[entry]
+fn main() -> ! {
+    X.store(div64 as usize, Ordering::Relaxed);
+
+    loop {}
+}
+
+fn div64(x: u64, y: u64) -> u64 {
+    x / y
+}
+
+#[exception]
+fn SysTick() {
+    X.fetch_add(1, Ordering::Relaxed);
+}

--- a/tests/examples.rs
+++ b/tests/examples.rs
@@ -188,6 +188,13 @@ fn panic_fmt() {
     }
 }
 
+#[test]
+fn div64() {
+    if channel_is_nightly() {
+        let _should_not_error = call_stack("div64");
+    }
+}
+
 fn channel_is_nightly() -> bool {
     rustc_version::version_meta().map(|m| m.channel).ok() == Some(Channel::Nightly)
 }


### PR DESCRIPTION
Fixes https://github.com/japaric/cargo-call-stack/issues/45

Instead of attempting to handle `#[naked]` specially, I just changed the code to ignore LLVM's stack usage info as soon as there's *any* inline assembly in a function. This should be more correct, since LLVM doesn't account for any stack pointer manipulation in inline assembly, but our thumb disassembler does (so the issue could manifest with any code that uses inline assembly).