### PR TITLE
Fix parsing

### DIFF
--- a/src/ir.rs
+++ b/src/ir.rs
@@ -242,7 +242,7 @@ fn getelementptr(i: &str) -> IResult<&str, GetElementPtr> {
 }
 
 fn name(i: &str) -> IResult<&str, &str> {
-    alt((map(string, |s| s.0), map(ident, |i| i.0)))(i)
+    alt((map(string, |s| s.0), map(ident, |i| i.0), digit1))(i)
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]

--- a/src/ir/define.rs
+++ b/src/ir/define.rs
@@ -161,6 +161,7 @@ fn argument(i: &str) -> IResult<&str, Argument> {
         map(super::bitcast, drop),
         map(super::getelementptr, drop),
         map(super::local, drop),
+        map(super::function, drop),
         map(digit1, drop),
     ))(i)?
     .0;

--- a/src/ir/item.rs
+++ b/src/ir/item.rs
@@ -269,6 +269,11 @@ mod tests {
     #[test]
     fn type_() {
         assert_eq!(
+            super::type_("%0 = type { i32, { i8*, i8* } }"),
+            Ok(("", Item::Type))
+        );
+
+        assert_eq!(
             super::type_("%\"blue_pill::ItmLogger\" = type {}"),
             Ok(("", Item::Type))
         );


### PR DESCRIPTION
This commit fixes some parsing errors I had.
Maybe this fixes #22, #28, #32 and #33.

Parsing is fixed for my own project, though I still have logged errors (at least the dot file is generated):
```
[2022-04-28T15:23:33Z ERROR cargo_call_stack] BUG? no callees for `void ({}*)`
[2022-04-28T15:23:33Z ERROR cargo_call_stack] BUG? no callees for `void ({}*, void ({}*)*)`
```