### PR TITLE
use a smaller 'std' facade for no-std targets 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
           override: true
           profile: minimal
           target: thumbv7m-none-eabi
-          toolchain: nightly
+          toolchain: nightly-2022-06-22
       - run: rustup target add thumbv6m-none-eabi
       - run: cargo install --path . --debug
       - name: Can analyze example firmware

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,8 @@ jobs:
           override: true
           profile: minimal
           target: thumbv7m-none-eabi
-          toolchain: nightly-2022-06-18
+          toolchain: nightly
+      - run: rustup target add thumbv6m-none-eabi
       - run: cargo install --path . --debug
       - name: Can analyze example firmware
         run: cargo test

--- a/cortex-m-examples/Cargo.toml
+++ b/cortex-m-examples/Cargo.toml
@@ -6,13 +6,12 @@ name = "app"
 version = "0.1.0"
 
 [dependencies]
-cortex-m = "0.5.8"
-cortex-m-rt = "0.6.5"
-cortex-m-semihosting = "0.3.2"
-defmt = "0.2.3"
+cortex-m = "0.7.5"
+cortex-m-rt = "0.7.1"
+cortex-m-semihosting = "0.5.0"
+defmt = "0.3.2"
 panic-halt = "0.2.0"
-spin = "0.5.0"
-defmt-rtt = "0.2.0"
+defmt-rtt = "0.3.2"
 
 [features]
 default = ["defmt-default"]

--- a/cortex-m-examples/examples/cycle.rs
+++ b/cortex-m-examples/examples/cycle.rs
@@ -1,18 +1,16 @@
 #![no_main]
 #![no_std]
 
-extern crate panic_halt;
-
 use core::{
     arch::asm,
     sync::atomic::{AtomicBool, Ordering},
 };
 
 use cortex_m_rt::{entry, exception};
+use panic_halt as _;
 
 static X: AtomicBool = AtomicBool::new(true);
 
-#[inline(never)]
 #[entry]
 fn main() -> ! {
     foo();

--- a/cortex-m-examples/examples/defmt.rs
+++ b/cortex-m-examples/examples/defmt.rs
@@ -18,7 +18,7 @@ defmt::timestamp!("{=usize}", {
 
 #[entry]
 fn main() -> ! {
-    defmt::info!("Hello, world!");
+    defmt::println!("Hello, world!");
 
     loop {}
 }

--- a/cortex-m-examples/examples/div64.rs
+++ b/cortex-m-examples/examples/div64.rs
@@ -21,5 +21,6 @@ fn div64(x: u64, y: u64) -> u64 {
 
 #[exception]
 fn SysTick() {
-    X.fetch_add(1, Ordering::Relaxed);
+    let old = X.load(Ordering::Relaxed);
+    X.store(old.wrapping_add(1), Ordering::Relaxed);
 }

--- a/cortex-m-examples/examples/fmul.rs
+++ b/cortex-m-examples/examples/fmul.rs
@@ -1,11 +1,10 @@
 #![no_main]
 #![no_std]
 
-extern crate panic_halt;
-
 use core::sync::atomic::{AtomicU32, Ordering};
 
 use cortex_m_rt::exception;
+use panic_halt as _;
 
 static X: AtomicU32 = AtomicU32::new(0);
 
@@ -21,5 +20,6 @@ fn main() -> ! {
 
 #[exception]
 fn SysTick() {
-    X.fetch_add(1, Ordering::Relaxed);
+    let old = X.load(Ordering::Relaxed);
+    X.store(old.wrapping_add(1), Ordering::Relaxed);
 }

--- a/cortex-m-examples/examples/fn.rs
+++ b/cortex-m-examples/examples/fn.rs
@@ -1,18 +1,16 @@
 #![no_main]
 #![no_std]
 
-extern crate panic_halt;
-
 use core::{
     arch::asm,
     sync::atomic::{AtomicPtr, Ordering},
 };
 
 use cortex_m_rt::{entry, exception};
+use panic_halt as _;
 
 static F: AtomicPtr<fn() -> bool> = AtomicPtr::new(foo as *mut _);
 
-#[inline(never)]
 #[entry]
 fn main() -> ! {
     if let Some(f) = unsafe { F.load(Ordering::Relaxed).as_ref() } {
@@ -38,8 +36,8 @@ fn foo() -> bool {
 fn bar() -> bool {
     unsafe {
         asm!(
-            "// {0} {1} {2} {3} {4} {5} {6} {7}",
-            in(reg) 0, in(reg) 1, in(reg) 2, in(reg) 3, in(reg) 4, in(reg) 5, in(reg) 6, in(reg) 7,
+            "// {0} {1} {2} {3} {4} {5} {6}",
+            in(reg) 0, in(reg) 1, in(reg) 2, in(reg) 3, in(reg) 4, in(reg) 5, in(reg) 6,
         );
     }
 

--- a/tests/examples.rs
+++ b/tests/examples.rs
@@ -2,10 +2,17 @@ use std::{env, process::Command};
 
 use rustc_version::Channel;
 
+fn for_each_target(mut f: impl FnMut(&str)) {
+    for target in ["thumbv6m-none-eabi", "thumbv7m-none-eabi"] {
+        f(target)
+    }
+}
+
 #[test]
 fn cycle() {
     if channel_is_nightly() {
-        let dot = call_stack("cycle");
+        // function calls on ARMv6-M use the stack
+        let dot = call_stack("cycle", "thumbv7m-none-eabi");
 
         let mut found = false;
         for line in dot.lines() {
@@ -23,175 +30,189 @@ fn cycle() {
 #[test]
 fn fmul() {
     if channel_is_nightly() {
-        let dot = call_stack("fmul");
+        for_each_target(|target| {
+            let dot = call_stack("fmul", target);
 
-        let mut main = None;
-        let mut fmul = None;
+            let mut main = None;
+            let mut fmul = None;
 
-        for line in dot.lines() {
-            if line.contains("label=\"main\\n") {
-                main = Some(
-                    line.split_whitespace()
-                        .next()
-                        .unwrap()
-                        .parse::<u32>()
-                        .unwrap(),
-                );
-            } else if line.contains("label=\"__aeabi_fmul\\n") {
-                fmul = Some(
-                    line.split_whitespace()
-                        .next()
-                        .unwrap()
-                        .parse::<u32>()
-                        .unwrap(),
-                );
+            for line in dot.lines() {
+                if line.contains("label=\"main\\n") {
+                    main = Some(
+                        line.split_whitespace()
+                            .next()
+                            .unwrap()
+                            .parse::<u32>()
+                            .unwrap(),
+                    );
+                } else if line.contains("label=\"__aeabi_fmul\\n") {
+                    fmul = Some(
+                        line.split_whitespace()
+                            .next()
+                            .unwrap()
+                            .parse::<u32>()
+                            .unwrap(),
+                    );
+                }
             }
-        }
 
-        let main = main.unwrap();
-        let fmul = fmul.unwrap();
+            let main = main.unwrap();
+            let fmul = fmul.unwrap();
 
-        // there must be an edge between `main` and `__aeabi_fmul`
-        assert!(dot.contains(&format!("{} -> {}", main, fmul)));
+            // there must be an edge between `main` and `__aeabi_fmul`
+            assert!(dot.contains(&format!("{} -> {}", main, fmul)));
+        })
     }
 }
 
 #[test]
 fn fun() {
     if channel_is_nightly() {
-        let dot = call_stack("fn");
+        for_each_target(|target| {
+            let dot = call_stack("fn", target);
 
-        let mut foo = None;
-        let mut bar = None;
-        let mut fun = None;
+            let mut foo = None;
+            let mut bar = None;
+            let mut fun = None;
 
-        for line in dot.lines() {
-            if line.contains("label=\"fn::foo\\n") {
-                foo = Some(
-                    line.split_whitespace()
-                        .next()
-                        .unwrap()
-                        .parse::<u32>()
-                        .unwrap(),
-                );
-            } else if line.contains("label=\"fn::bar\\n") {
-                bar = Some(
-                    line.split_whitespace()
-                        .next()
-                        .unwrap()
-                        .parse::<u32>()
-                        .unwrap(),
-                );
-            } else if line.contains("label=\"i1 ()*\\n") {
-                fun = Some(
-                    line.split_whitespace()
-                        .next()
-                        .unwrap()
-                        .parse::<u32>()
-                        .unwrap(),
-                );
+            for line in dot.lines() {
+                if line.contains("label=\"fn::foo\\n") {
+                    foo = Some(
+                        line.split_whitespace()
+                            .next()
+                            .unwrap()
+                            .parse::<u32>()
+                            .unwrap(),
+                    );
+                } else if line.contains("label=\"fn::bar\\n") {
+                    bar = Some(
+                        line.split_whitespace()
+                            .next()
+                            .unwrap()
+                            .parse::<u32>()
+                            .unwrap(),
+                    );
+                } else if line.contains("label=\"i1 ()*\\n") {
+                    fun = Some(
+                        line.split_whitespace()
+                            .next()
+                            .unwrap()
+                            .parse::<u32>()
+                            .unwrap(),
+                    );
+                }
             }
-        }
 
-        let fun = fun.unwrap();
-        let foo = foo.unwrap();
-        let bar = bar.unwrap();
+            let fun = fun.unwrap();
+            let foo = foo.unwrap();
+            let bar = bar.unwrap();
 
-        // there must be an edge from the fictitious node to both `foo` and `bar`
-        assert!(dot.contains(&format!("{} -> {}", fun, foo)));
-        assert!(dot.contains(&format!("{} -> {}", fun, bar)));
+            // there must be an edge from the fictitious node to both `foo` and `bar`
+            assert!(dot.contains(&format!("{} -> {}", fun, foo)));
+            assert!(dot.contains(&format!("{} -> {}", fun, bar)));
+        })
     }
 }
 
 #[test]
 fn to() {
     if channel_is_nightly() {
-        let dot = call_stack("to");
+        for_each_target(|target| {
+            let dot = call_stack("to", target);
 
-        let mut bar = None;
-        let mut baz = None;
-        let mut quux = None;
-        let mut to = None;
+            let mut bar = None;
+            let mut baz = None;
+            let mut quux = None;
+            let mut to = None;
 
-        for line in dot.lines() {
-            if line.contains("label=\"to::Foo::foo\\n") {
-                bar = Some(
-                    line.split_whitespace()
-                        .next()
-                        .unwrap()
-                        .parse::<u32>()
-                        .unwrap(),
-                );
-            } else if line.contains("label=\"<to::Baz as to::Foo>::foo\\n") {
-                baz = Some(
-                    line.split_whitespace()
-                        .next()
-                        .unwrap()
-                        .parse::<u32>()
-                        .unwrap(),
-                );
-            } else if line.contains("label=\"to::Quux::foo\\n") {
-                quux = Some(
-                    line.split_whitespace()
-                        .next()
-                        .unwrap()
-                        .parse::<u32>()
-                        .unwrap(),
-                );
-            } else if line.contains("label=\"i1 ({}*)\\n") {
-                to = Some(
-                    line.split_whitespace()
-                        .next()
-                        .unwrap()
-                        .parse::<u32>()
-                        .unwrap(),
-                );
+            for line in dot.lines() {
+                if line.contains("label=\"to::Foo::foo\\n") {
+                    bar = Some(
+                        line.split_whitespace()
+                            .next()
+                            .unwrap()
+                            .parse::<u32>()
+                            .unwrap(),
+                    );
+                } else if line.contains("label=\"<to::Baz as to::Foo>::foo\\n") {
+                    baz = Some(
+                        line.split_whitespace()
+                            .next()
+                            .unwrap()
+                            .parse::<u32>()
+                            .unwrap(),
+                    );
+                } else if line.contains("label=\"to::Quux::foo\\n") {
+                    quux = Some(
+                        line.split_whitespace()
+                            .next()
+                            .unwrap()
+                            .parse::<u32>()
+                            .unwrap(),
+                    );
+                } else if line.contains("label=\"i1 ({}*)\\n") {
+                    to = Some(
+                        line.split_whitespace()
+                            .next()
+                            .unwrap()
+                            .parse::<u32>()
+                            .unwrap(),
+                    );
+                }
             }
-        }
 
-        let bar = bar.unwrap();
-        let baz = baz.unwrap();
-        let quux = quux.unwrap();
-        let to = to.unwrap();
+            let bar = bar.unwrap();
+            let baz = baz.unwrap();
+            let quux = quux.unwrap();
+            let to = to.unwrap();
 
-        // there must be an edge from the fictitious node to both `Bar` and `Baz`
-        assert!(dot.contains(&format!("{} -> {}", to, bar)));
-        assert!(dot.contains(&format!("{} -> {}", to, baz)));
+            // there must be an edge from the fictitious node to both `Bar` and `Baz`
+            assert!(dot.contains(&format!("{} -> {}", to, bar)));
+            assert!(dot.contains(&format!("{} -> {}", to, baz)));
 
-        // but there must not be an edge from the fictitious node and `Quux`
-        assert!(!dot.contains(&format!("{} -> {}", to, quux)));
+            // but there must not be an edge from the fictitious node and `Quux`
+            assert!(!dot.contains(&format!("{} -> {}", to, quux)));
+        })
     }
 }
 
 #[test]
 fn defmt() {
     if channel_is_nightly() {
-        let dot = call_stack("defmt");
-        assert!(
-            dot.contains(&"label=\"Reset\\nmax = "),
-            "could not compute an upper for entry point"
-        );
+        for_each_target(|target| {
+            let dot = call_stack("defmt", target);
+            assert!(
+                dot.contains(&"label=\"main\\nmax = "),
+                "could not compute an upper for `main`"
+            );
+        })
     }
 }
 
 #[test]
 fn fmt() {
     if channel_is_nightly() {
-        let _should_not_error = call_stack("fmt");
+        for_each_target(|target| {
+            let _should_not_error = call_stack("fmt", target);
+        })
     }
 }
 
 #[test]
 fn panic_fmt() {
     if channel_is_nightly() {
-        let _should_not_error = call_stack("panic-fmt");
+        for_each_target(|target| {
+            let _should_not_error = call_stack("panic-fmt", target);
+        })
     }
 }
 
 #[test]
 fn div64() {
     if channel_is_nightly() {
-        let _should_not_error = call_stack("div64");
+        for_each_target(|target| {
+            let _should_not_error = call_stack("div64", target);
+        })
     }
 }
 
@@ -199,9 +220,9 @@ fn channel_is_nightly() -> bool {
     rustc_version::version_meta().map(|m| m.channel).ok() == Some(Channel::Nightly)
 }
 
-fn call_stack(ex: &str) -> String {
+fn call_stack(ex: &str, target: &str) -> String {
     let output = Command::new("cargo")
-        .args(&["call-stack", "--example", ex])
+        .args(&["call-stack", "--example", ex, "--target", target])
         .current_dir(env::current_dir().unwrap().join("cortex-m-examples"))
         .output()
         .unwrap();


### PR DESCRIPTION
fixes #55

`-Z build-std` builds a "no op" std for the target, even no-std ones
that won't work for ARMv6-M because std depends on CAS and that target
lacks CAS
ARMv7-M also has problems with recent nightlies due to
rust-lang/rust#98378

this commit changes the logic to use a smaller `-Z build-std=alloc`
subset for no-std targets
targets are considered 'no-std' when `rustc --print=cfg --target $T`
reports `target_os="none"`
