### PR TITLE
heuristic: memcmp can be directly lowered to machine code

### DIFF
--- a/cortex-m-examples/examples/memcmp-no.rs
+++ b/cortex-m-examples/examples/memcmp-no.rs
@@ -1,0 +1,25 @@
+#![no_main]
+#![no_std]
+
+use core::{cmp::Ordering, ptr};
+
+use panic_halt as _;
+
+#[cortex_m_rt::entry]
+fn main() -> ! {
+    unsafe {
+        let no = no as usize;
+        ptr::addr_of!(no).read_volatile();
+    }
+    loop {}
+}
+
+// as seen in issue #63 this produces `call @memcmp` in LLVM IR but the intrinsic then is lowered to
+// machine code by llvm and there's no `memcmp` symbol in the output ELF
+fn no(a: &str, b: &str) -> bool {
+    if a.len() == 4 && b.len() == 4 {
+        a.cmp(b) == Ordering::Equal
+    } else {
+        false
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -734,6 +734,14 @@ fn run() -> Result<i32, failure::Error> {
                         func
                     );
 
+                    // some intrinsics can be directly lowered to machine code
+                    // if the intrinsic has no corresponding node (symbol in the output ELF) assume
+                    // that it has been lowered to machine code
+                    const SYMBOLLESS_INTRINSICS: &[&str] = &["memcmp"];
+                    if SYMBOLLESS_INTRINSICS.contains(func) && !indices.contains_key(*func) {
+                        continue;
+                    }
+
                     // use canonical name
                     let callee = if let Some(canon) = aliases.get(func) {
                         indices[*canon]

--- a/tests/examples.rs
+++ b/tests/examples.rs
@@ -216,6 +216,15 @@ fn div64() {
     }
 }
 
+#[test]
+fn gh63() {
+    if channel_is_nightly() {
+        for_each_target(|target| {
+            let _should_not_error = call_stack("memcmp-no", target);
+        })
+    }
+}
+
 fn channel_is_nightly() -> bool {
     rustc_version::version_meta().map(|m| m.channel).ok() == Some(Channel::Nightly)
 }


### PR DESCRIPTION
fixes #63