### PR TITLE
Add --link-arg command

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -79,6 +79,10 @@ struct Args {
     #[arg(long, default_value = "dot")]
     format: OutputFormat,
 
+    /// Linker argument (can be specified multiple times)
+    #[arg(long, value_name = "LINK_ARG")]
+    link_arg: Vec<String>,
+
     /// consider only the call graph that starts from this node
     start: Option<String>,
 }
@@ -179,6 +183,11 @@ fn run() -> anyhow::Result<i32> {
         "-C",
         "lto=fat",
     ]);
+
+    for link_arg in &args.link_arg {
+        cargo.arg("-C");
+        cargo.arg(&format!("link-arg={link_arg}"));
+    }
 
     cargo.env("CARGO_CALL_STACK_RUSTC_WRAPPER", "1");
     cargo.env("RUSTC_WRAPPER", env::current_exe()?);


### PR DESCRIPTION
Allows specifying things like custom linker scripts which may be required for some embedded projects.