### PR TITLE
Fix positional arguments

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -51,6 +51,10 @@ enum OutputFormat {
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
 struct Args {
+
+    /// The subcommand of this cargo invocation. Should always be "call-stack".
+    _cargo_subcommand: String,
+
     /// Target triple for which the code is compiled
     #[arg(long, value_name = "TRIPLE")]
     target: Option<String>,


### PR DESCRIPTION
Add a cargo-subcommand argument so that when invoked from cargo the positional arguments ("start") parse from the correct value.

Fix #99